### PR TITLE
fix: configuration `workflowWithTests` should be ignored if bot is used as GitHub Action

### DIFF
--- a/src/classes/bot.ts
+++ b/src/classes/bot.ts
@@ -497,18 +497,19 @@ export class ScreenshotBot<T extends EmitterWebhookEventName> extends Bot<T> {
 
         const { workflowWithTests, branchesIgnore } = this.botConfigs;
 
-        const workflowWithNoTests =
-            !workflowName ||
-            !workflowWithTests.some((regExp) =>
-                new RegExp(regExp, 'gi').test(workflowName)
-            );
+        const hasTests =
+            process.env.GITHUB_ACTIONS ||
+            (workflowName &&
+                workflowWithTests.some((regExp) =>
+                    new RegExp(regExp, 'gi').test(workflowName)
+                ));
         const branchIgnored =
             !!workflowBranch &&
             branchesIgnore.some((regExp) =>
                 new RegExp(regExp, 'gi').test(workflowBranch)
             );
 
-        return workflowWithNoTests || branchIgnored;
+        return !hasTests || branchIgnored;
     }
 
     async deleteUploadedImagesFolder(prNumber: number) {


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables

<img width="765" height="97" alt="Снимок экрана 2025-07-28 в 12 16 31" src="https://github.com/user-attachments/assets/f4a6a863-6e87-4c68-8f49-e3759c5a63b8" />
